### PR TITLE
Fix dependency of ruby that y2metainfo need.

### DIFF
--- a/package/yast2-geo-cluster.spec
+++ b/package/yast2-geo-cluster.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-geo-cluster
 #
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -27,11 +27,12 @@ Url:            https://github.com/yast/yast-geo-cluster
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
+BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 4.2.2
 
 # SuSEFirewall2 replaced by Firewalld(fate#323460)
-Requires:       yast2 >= 4.0.39
 Requires:       autoyast2-installation
+Requires:       yast2 >= 4.0.39
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 BuildArch:      noarch


### PR DESCRIPTION
Add buildrequest yast2 for dependency of
/usr/share/YaST2/data/devtools/bin/y2metainfo
Refer to:
[pr of import metainfo](https://github.com/yast/yast-geo-cluster/pull/26)
[failed ci job](http://ci.opensuse.org/job/yast-yast-geo-cluster-master/10/)