### PR TITLE
Fix schema for inclusion in yast2-schema (profile.rnc) (bsc#1170886)

### DIFF
--- a/package/yast2-geo-cluster.changes
+++ b/package/yast2-geo-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 27 15:03:16 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Autoyast schema: Fix for inclusion in yast2-schema (bsc#1170886)
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu May  7 11:30:46 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-geo-cluster.spec
+++ b/package/yast2-geo-cluster.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-geo-cluster
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        Configuration of booth
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/geo-cluster.rnc
+++ b/src/autoyast-rnc/geo-cluster.rnc
@@ -4,75 +4,40 @@ namespace config = "http://www.suse.com/1.0/configns"
 
 include "common.rnc"
 
+int_noempty = STRING_ATTR, (xsd:integer | empty)
+simple_listentry = element listentry { STRING }
+
 geo-cluster =
   element geo-cluster {
       LIST,
       booth_config*
   }
 
-int_noempty = STRING_ATTR, (xsd:integer | empty)
-
-filename = element filename { STRING }
-authfile = element authfile { STRING }
-port = element port { int_noempty }
-transport = element transport { STRING }
-
-simple_listentry = element listentry { STRING }
-
-arbitrators =
-  element arbitrator {
-      LIST,
-      simple_listentry*
+booth_config =
+  element listentry {
+    MAP,
+    (
+      element filename { STRING } ? &
+      element authfile { STRING } ? &
+      element port { int_noempty } ? &
+      element transport { STRING } ? &
+      element arbitrator { LIST, simple_listentry* } ? &
+      element site { LIST, simple_listentry* } ? &
+      element ticket { LIST, ticket_listentry* } ?
+    )
   }
-
-sites =
-  element site {
-      LIST,
-      simple_listentry*
-  }
-
-acquire-after = element acquire-after { int_noempty }
-before-acquire-handler = element before-acquire-handler { STRING }
-expire = element expire { int_noempty }
-retries = element retries { int_noempty }
-ticketname = element ticketname { STRING }
-timeout = element timeout { int_noempty }
-weights = element weights { int_noempty }
-mode = element mode { STRING }
 
 ticket_listentry =
   element listentry {
     MAP,
     (
-      acquire-after? &
-      before-acquire-handler? &
-      expire? &
-      retries? &
-      ticketname? &
-      timeout? &
-      weights? &
-      mode?
+      element acquire-after { int_noempty } ? &
+      element before-acquire-handler { STRING } ? &
+      element expire { int_noempty } ? &
+      element retries { int_noempty } ? &
+      element ticketname { STRING } ? &
+      element timeout { int_noempty } ? &
+      element weights { int_noempty } ? &
+      element mode { STRING } ?
     )
   }
-
-tickets =
-  element ticket {
-      LIST,
-      ticket_listentry*
-  }
-
-booth_config =
-  element listentry {
-    MAP,
-    (
-      filename? &
-      authfile? &
-      port? &
-      transport? &
-      arbitrators? &
-      sites? &
-      tickets?
-    )
-  }
-
-start = geo-cluster


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1170886

Formerly this was a standalone schema but now it's included in the AY schema    so we need to remove the 'start' declaration    and remove the defines that conflict with other packages.
    (Inlining most of defines makes the schema more readable too)
    
This fixes these errors:
```
    yast2-schema-4.3.0/src/rng/users.rng:113:25: error: multiple definitions of "expire" without "combine" attribute
    yast2-schema-4.3.0/src/rng/reporting.rng:69:26: error: multiple definitions of "timeout" without "combine" attribute
    yast2-schema-4.3.0/src/rng/scripts.rng:197:27: error: multiple definitions of "filename" without "combine" attribute
    yast2-schema-4.3.0/src/rng/profile.rng:355:10: error: multiple definitions of start without "combine" attribute
```